### PR TITLE
Add config folder and add cors config file

### DIFF
--- a/src/main/java/com/example/cvd/config/CorsConfig.java
+++ b/src/main/java/com/example/cvd/config/CorsConfig.java
@@ -8,10 +8,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig {
 
-    static {
-        System.out.println("✅ CorsConfig loaded successfully");
-    }
-    
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {


### PR DESCRIPTION
Create a config folder and add CorsConfig.java file that allows us to call to API from our web front end, so we don't get errors. May need to switch out localhost:8081 with actual web host name later on, when it gets hosted correctly on Heroku.